### PR TITLE
Fix #40: Agregar uso de ~/.default-python-packages

### DIFF
--- a/defaults/main/asdf.yml
+++ b/defaults/main/asdf.yml
@@ -27,7 +27,6 @@ workstation_asdf_tools:
   oc: []
   packer: []
   php: []
-  pre-commit: [ ]
   python: [3.10.16, 3.11.11]
   restic: []
   ruby: []

--- a/defaults/main/asdf.yml
+++ b/defaults/main/asdf.yml
@@ -41,6 +41,9 @@ workstation_asdf_tools:
   trivy: []
   velero: []
   yq: [ latest ]
+workstation_default_python_packages:
+  - pre-commit
+
 # List of plugins not published in central repo:
 # https://github.com/asdf-vm/asdf-plugins
 workstation_asdf_external_sources_plugins:

--- a/tasks/asdf.yml
+++ b/tasks/asdf.yml
@@ -18,6 +18,12 @@
           {{ "tar xfz %downloaded% -C %install_directory% asdf" | replace('%install_directory%', workstation_asdf_dest + '/bin') }}
         version_command: "asdf version"
 
+- name: "Create default python packages"
+  ansible.builtin.copy:
+    content: |
+      pre-commit
+    dest: "{{ ansible_env.HOME }}/.default-python-packages"   
+
 - name: "Check asdf installed plugins"
   ansible.builtin.command: "asdf plugin list"
   register: asdf_plugin_list_output

--- a/tasks/asdf.yml
+++ b/tasks/asdf.yml
@@ -20,9 +20,8 @@
 
 - name: "Create default python packages"
   ansible.builtin.copy:
-    content: |
-      pre-commit
-    dest: "{{ ansible_env.HOME }}/.default-python-packages"   
+    content: "{{ workstation_default_python_packages | join('\n') }}\n"
+    dest: "{{ ansible_env.HOME }}/.default-python-packages"
 
 - name: "Check asdf installed plugins"
   ansible.builtin.command: "asdf plugin list"

--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -28,6 +28,7 @@ workstation_packages:
   - xsel
   - xclip
   - openssl
+  - sqlite
 
 workstation_yay_packages:
   - swaks

--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -26,6 +26,7 @@ workstation_packages:
   - python-pip
   - rust
   - shellcheck
+  - sqlite
   - tk
   - tmux
   - tree

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -30,6 +30,8 @@ workstation_packages:
   - xsel
   - yamllint
   - zsh
+  - libsqlite3-dev
+  - sqlite3
 
 workstation_apt_keys: []
 workstation_repositories: []

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -56,6 +56,8 @@ workstation_packages:
   - yamllint
   - zlib1g-dev
   - zsh
+  - libsqlite3-dev
+  - sqlite3
 
 workstation_apt_keys: []
 workstation_repositories: []

--- a/vars/ubuntu-20.04.yml
+++ b/vars/ubuntu-20.04.yml
@@ -32,6 +32,8 @@ workstation_packages:
   - xsel
   - xclip
   - libssl-dev
+  - libsqlite3-dev
+  - sqlite3
 
 workstation_apt_keys:
   - url: https://apt.releases.hashicorp.com/gpg


### PR DESCRIPTION
Se agregó un task que crea el .default-python-packages dentro de $HOME/. En este caso contiene _pre-commit_ y se eliminó este mismo de los plugins de asdf.
También se agregaron nuevos paquetes a instalar y sus dependencias ya que pre-commit las requiere para funcionar