### PR TITLE
Issue #19: Se agregan paquetes de sistema sugeridos para Arch Linux + Soporte para clipboard en Vim

### DIFF
--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -8,6 +8,7 @@ workstation_packages:
   - gcc
   - git
   - git-lfs
+  - gvim
   - haveged
   - jq
   - libffi
@@ -29,7 +30,6 @@ workstation_packages:
   - tmux
   - tree
   - unzip
-  - vim
   - wget
   - xclip
   - xsel

--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -1,33 +1,43 @@
 ---
 workstation_packages:
+  - asciinema
   - base-devel
   - bzip2
-  - python
-  - openssh
-  - wget
   - curl
-  - nmap
-  - jq
-  - unzip
-  - yamllint
+  - dnsutils
+  - gcc
   - git
   - git-lfs
-  - vim
-  - tmux
-  - openfortivpn
-  - openconnect
-  - shellcheck
-  - dnsutils
-  - ppp
-  - nextcloud-client
   - haveged
-  - asciinema
-  - tree
-  - podman
-  - zsh
-  - xsel
-  - xclip
+  - jq
+  - libffi
+  - libyaml
+  - make
+  - nextcloud-client
+  - nmap
+  - openconnect
+  - openfortivpn
+  - openssh
   - openssl
+  - podman
+  - ppp
+  - python
+  - python-pip
+  - rust
+  - shellcheck
+  - tk
+  - tmux
+  - tree
+  - unzip
+  - vim
+  - wget
+  - xclip
+  - xsel
+  - xz
+  - yamllint
+  - zlib
+  - zsh
+  - zstd
 
 workstation_yay_packages:
   - swaks


### PR DESCRIPTION
Se agrega soporte para la instalación de los paquetes de sistema sugeridos para python, ruby y node según lo indicado en el #19. Solo se ignoro para Ruby el paquete gcc6 ya que en Arch solo se puede agregar [a través de yay](https://github.com/rbenv/ruby-build/wiki#arch-linux) y el tiempo de ejecución del role se extiende a más de 2 horas en las pruebas debido a la demora en la compilación del paquete.

También se reemplaza el paquete vim por gvim ya que este último, además de agregar el vim gráfico también agrega la versión CLI de Vim que tiene soporte para features como +clipboard, +xterm_clipboard y +wayland_clipboard. Se trata de un reemplazo porque el paquete vim y gvim son excluyentes entre sí y `pacman` no permite tener ambos paquetes a la vez. 