### PR TITLE
Agrega soporte para Redhat distros

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,20 +6,20 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: arch
-    image: 'archlinux:base'
-    groups:
-      - complete
-  - name: ubuntu-2404
-    image: 'ubuntu:24.04'
-    groups:
-      - system_packages
-  - name: debian-12
-    image: 'debian:12'
-    groups:
-      - complete
-  - name: rocky-9
-    image: 'rockylinux:9'
+  # - name: arch
+  #   image: 'archlinux:base'
+  #   groups:
+  #     - complete
+  # - name: ubuntu-2404
+  #   image: 'ubuntu:24.04'
+  #   groups:
+  #     - system_packages
+  # - name: debian-12
+  #   image: 'debian:12'
+  #   groups:
+  #     - complete
+  - name: alma-9
+    image: 'almalinux:9.6'
     groups:
       - complete
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,8 +18,8 @@ platforms:
     image: 'debian:12'
     groups:
       - complete
-  - name: redhat-9
-    image: 'registry.access.redhat.com/ubi9/ubi:latest'
+  - name: rocky-9
+    image: 'rockylinux:9'
     groups:
       - complete
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,6 +18,10 @@ platforms:
     image: 'debian:12'
     groups:
       - complete
+  - name: redhat-9
+    image: 'registry.access.redhat.com/ubi9/ubi:latest'
+    groups:
+      - complete
 provisioner:
   name: ansible
   inventory:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,18 +6,18 @@ dependency:
 driver:
   name: docker
 platforms:
-  # - name: arch
-  #   image: 'archlinux:base'
-  #   groups:
-  #     - complete
-  # - name: ubuntu-2404
-  #   image: 'ubuntu:24.04'
-  #   groups:
-  #     - system_packages
-  # - name: debian-12
-  #   image: 'debian:12'
-  #   groups:
-  #     - complete
+  - name: arch
+    image: 'archlinux:base'
+    groups:
+      - complete
+  - name: ubuntu-2404
+    image: 'ubuntu:24.04'
+    groups:
+      - system_packages
+  - name: debian-12
+    image: 'debian:12'
+    groups:
+      - complete
   - name: alma-9
     image: 'almalinux:9.6'
     groups:

--- a/tasks/system_packages.yml
+++ b/tasks/system_packages.yml
@@ -1,6 +1,16 @@
 ---
--
-  name: Include release specific variables
+- name: Debug detected distribution facts
+  ansible.builtin.debug:
+    msg: |
+      ansible_distribution: {{ ansible_distribution | default('undefined') }}
+      ansible_distribution_version: {{ ansible_distribution_version | default('undefined') }}
+      ansible_distribution_major_version: {{ ansible_distribution_major_version | default('undefined') }}
+      ansible_os_family: {{ ansible_os_family | default('undefined') }}
+      ansible_pkg_mgr: {{ ansible_pkg_mgr | default('undefined') }}
+  tags:
+    - debug
+
+- name: Include release specific variables
   ansible.builtin.include_vars: "{{ _loop_var }}"
   loop: "{{ query('first_found', _params) }}"
   loop_control:
@@ -70,10 +80,13 @@
       changed_when: false
 -
   name: Setup configured locale
-  community.general.locale_gen:
-    name: "{{ item }}"
-    state: present
-  become: true
-  tags:
-    - locales
-  with_items: "{{ workstation_locales }}"
+  when: ansible_os_family | lower in ['debian', 'debianlike', 'ubuntu'] or (ansible_distribution | lower).startswith('ubuntu')
+  block:
+    - name: Setup configured locale
+      community.general.locale_gen:
+        name: "{{ item }}"
+        state: present
+      become: true
+      tags:
+        - locales
+      with_items: "{{ workstation_locales }}"

--- a/tasks/system_packages_redhat.yml
+++ b/tasks/system_packages_redhat.yml
@@ -1,0 +1,49 @@
+---
+- name: Ensure dnf-plugins-core present (for repos)
+  ansible.builtin.package:
+    name: dnf-plugins-core
+    state: present
+  become: true
+
+- name: Enable EPEL repository when requested
+  when: workstation_enable_epel | default(false)
+  become: true
+  block:
+    - name: Attempt to install epel-release via package manager
+      ansible.builtin.package:
+        name: epel-release
+        state: present
+      register: epel_install
+      ignore_errors: true
+
+    - name: Install epel-release RPM from Fedora if package not available
+      ansible.builtin.get_url:
+        url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+        dest: /tmp/epel-release.rpm
+        mode: "0644"
+      when: epel_install is failed or (epel_install is defined and epel_install.rc is defined and epel_install.rc != 0)
+
+    - name: Import EPEL GPG key from Fedora project
+      ansible.builtin.rpm_key:
+        key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+        state: present
+      when: epel_install is failed or (epel_install is defined and epel_install.rc is defined and epel_install.rc != 0)
+
+    - name: Install epel rpm file
+      ansible.builtin.package:
+        name: /tmp/epel-release.rpm
+        state: present
+      when: epel_install is failed or (epel_install is defined and epel_install.rc is defined and epel_install.rc != 0)
+
+    - name: Remove temporary epel rpm
+      ansible.builtin.file:
+        path: /tmp/epel-release.rpm
+        state: absent
+      when: epel_install is failed or (epel_install is defined and epel_install.rc is defined and epel_install.rc != 0)
+
+- name: Update dnf/yum cache
+  ansible.builtin.package:
+    update_cache: yes
+  tags:
+    - molecule-idempotence-notest
+  become: true

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,47 @@
+---
+# RHEL / RedHat-family variables
+workstation_packages:
+  - asciinema
+  - bzip2
+  - curl
+  - dnsutils
+  - git
+  - git-extras
+  - git-lfs
+  - haveged
+  - openssl-devel
+  - glibc-langpack-en
+  - glibc-langpack-es
+  - nmap
+  - openconnect
+  - openfortivpn
+  - openssh-server
+  - podman
+  - ppp
+  - python3
+  - shellcheck
+  - swaks
+  - tmux
+  - tree
+  - shadow-utils
+  - unzip
+  - vim
+  - wget
+  - xclip
+  - xsel
+  - yamllint
+  - zsh
+  - gcc
+  - gcc-c++
+  - make
+  - openssl-devel
+  - bzip2-devel
+  - libffi-devel
+  - zlib-devel
+  - xz-devel
+  - readline-devel
+  - sqlite-devel
+  - tk-devel
+  - ncurses-devel
+
+workstation_enable_epel: true

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -3,8 +3,7 @@
 workstation_packages:
   - asciinema
   - bzip2
-  - curl
-  - dnsutils
+  - bind-utils
   - git
   - git-extras
   - git-lfs
@@ -34,7 +33,6 @@ workstation_packages:
   - gcc
   - gcc-c++
   - make
-  - openssl-devel
   - bzip2-devel
   - libffi-devel
   - zlib-devel


### PR DESCRIPTION
Agrego soporte para redhat, tuve problemas para encontrar algunos de los paquetes, sobre todo el python3-venv, pero por lo demás logre que corra bien en un Red Hat Enterprise Linux 9.6