### PR TITLE
fix: usar --verify=false en helm plugin install (helm 3.16+)

### DIFF
--- a/tasks/helm-plugins.yml
+++ b/tasks/helm-plugins.yml
@@ -10,10 +10,16 @@
   name: Do install and upgrade helm plugins when installed
   when: helm_check.rc == 0
   block:
+    - name: Check installed helm plugins
+      ansible.builtin.command: helm plugin list
+      register: helm_plugins_installed
+      changed_when: false
+      environment:
+        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"
     - name: Install helm plugins
-      kubernetes.core.helm_plugin:
-        plugin_path: "{{ item.repo }}"
-        state: present
+      ansible.builtin.command: "helm plugin install {{ item.repo }} --verify=false"
       loop: "{{ workstation_helm_plugins }}"
+      when: item.name not in helm_plugins_installed.stdout
+      changed_when: true
       environment:
         PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"


### PR DESCRIPTION
## Summary

- Helm 3.16+ introdujo verificación de firma en plugins; sin `--verify=false` la instalación falla con `Error: plugin install failed`
- Se agrega el flag a todos los `helm plugin install` en `tasks/helm-plugins.yml`

## Test plan

- [ ] CI verde (molecule no instala helm plugins, pero ansible-lint valida la sintaxis)
- [ ] Verificar manualmente en una VM con helm 3.16+ que los plugins se instalan sin error