### PR TITLE
fix: omitir instalación de versiones asdf ya instaladas

### DIFF
--- a/tasks/asdf.yml
+++ b/tasks/asdf.yml
@@ -51,19 +51,39 @@
   environment:
     PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
 
+- name: "Check asdf version tools installed"
+  ansible.builtin.shell: |
+    if [ "{{ item.1 }}" = "latest" ]; then
+      latest=$(asdf latest {{ item.0.key }} 2>/dev/null)
+      asdf list {{ item.0.key }} 2>/dev/null | grep -qF "$latest"
+    else
+      asdf list {{ item.0.key }} 2>/dev/null | grep -qF '{{ item.1 }}'
+    fi
+  register: asdf_version_installed
+  failed_when: false
+  changed_when: false
+  environment:
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+  loop: "{{ workstation_asdf_tools | dict2items | subelements('value') }}"
+  loop_control:
+    label: "Checking asdf {{ item.0.key }}@{{ item.1 }}"
+    index_var: asdf_tool_idx
+
 - name: "Install asdf version tools"
   ansible.builtin.command: "asdf install {{ item.0.key }} {{ item.1 }}"
   register: asdf_output
   failed_when: asdf_output.rc != 0
-  changed_when: false
+  changed_when: true
   retries: 4
   delay: 3
   until: asdf_output.rc == 0
+  when: asdf_version_installed.results[asdf_tool_idx].rc != 0
   environment:
     PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
   loop: "{{ workstation_asdf_tools | dict2items | subelements('value') }}"
   loop_control:
     label: "Installing asdf {{ item.0.key }}@{{ item.1 }}"
+    index_var: asdf_tool_idx
 
 - name: "Install asdf set global tools"
   ansible.builtin.command: "asdf set --home {{ item.key }} {{ item.value | last }}"


### PR DESCRIPTION
## Problema

`asdf install <tool> <version>` se ejecutaba en cada run para todas las herramientas, aunque ya estuvieran instaladas. Con 17+ herramientas, esto generaba demoras innecesarias en runs subsiguientes.

## Solución

Agrega una tarea de check previo que usa `asdf list` y `asdf latest` para determinar si la versión ya está instalada, y saltea `asdf install` en ese caso.

- Para versiones específicas (ej: `3.11.11`): busca exactamente esa versión en `asdf list`
- Para `latest`: resuelve la versión actual con `asdf latest` y verifica si está instalada

## Resultado

En runs subsiguientes donde todo ya está instalado, los `asdf install` pasan de `ok` a `skipping`, reduciendo el tiempo de ejecución significativamente.