### PR TITLE
feat: agregar uv a herramientas instaladas por defecto via asdf

### DIFF
--- a/defaults/main/asdf.yml
+++ b/defaults/main/asdf.yml
@@ -39,6 +39,7 @@ workstation_asdf_tools:
   terragrunt: [ latest ]
   tflint: [ latest ]
   trivy: []
+  uv: [ latest ]
   velero: []
   yq: [ latest ]
 workstation_default_python_packages:


### PR DESCRIPTION
## Summary

Agrega `uv` al listado de herramientas instaladas por defecto via asdf.

Esto permite que en ejecuciones posteriores del playbook, `uv` esté disponible automáticamente sin necesidad de instalarlo manualmente antes de correr el playbook.