### PR TITLE
fix: usar endpoint dualstack de S3 para descargar gitlab-runner

### DIFF
--- a/defaults/main/tools-others.yml
+++ b/defaults/main/tools-others.yml
@@ -41,7 +41,7 @@ workstation_other_tools:
   -
     name: gitlab-runner
     url: >-
-      https://gitlab-runner-downloads.s3.amazonaws.com/v%version%/binaries/gitlab-runner-{{ ansible_system | lower }}-amd64
+      https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/v%version%/binaries/gitlab-runner-{{ ansible_system | lower }}-amd64
     version: '15.11.1'
     install_command: >-
       chmod +x %downloaded% &&


### PR DESCRIPTION
## Problema

El endpoint `gitlab-runner-downloads.s3.amazonaws.com` es el legacy de S3 y tiene problemas de conectividad desde ciertas redes (en particular desde VMs con NAT de VirtualBox), causando timeouts al descargar el binario.

## Fix

Cambia la URL al endpoint oficial con región explícita:
`s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/...`

Este endpoint usa el routing correcto de AWS y tiene mejor conectividad.