### PR TITLE
fix: agregar GITHUB_API_TOKEN para evitar rate limiting en instalaciones

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,4 @@
 use asdf
 layout python
+
+source_env_if_exists .envrc.private

--- a/.envrc.private.sample
+++ b/.envrc.private.sample
@@ -1,0 +1,6 @@
+# Copiar este archivo a .envrc.private y completar los valores.
+# .envrc.private está en .gitignore y nunca se commitea.
+
+# Token de GitHub para evitar rate limiting al instalar plugins de asdf.
+# Crear en https://github.com/settings/tokens (sin scopes necesarios).
+export GITHUB_API_TOKEN=github_pat_...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .direnv/
 .tox/
+.envrc.private

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Role mikroways.workstation
 
-Este role instala las herramientas que usamos a dirario en Mikroways. Es una
+Este role instala las herramientas que usamos a diario en Mikroways. Es una
 forma de mantener el workstation de nuestros talentos con las versiones de
 aquellas herramientas usadas, como así simplificar la generación de bastiones
 que nos entregan nuestros clientes y nos permiten trabajar cómodamente.
@@ -27,7 +27,6 @@ En resumen, este role realiza las siguientes tareas:
   Mikroways](https://github.com/Mikroways/dotfiles).
 * Además, se instalan plugins de helm y krew que más usamos en Mikroways.
 
-
 De esta forma, corriendo este role, disponemos de un desktop listo para empezar
 a trabajar.
 
@@ -52,11 +51,11 @@ Simplemente agregás en `requirements.yml` las siguientes lineas:
 
 > ¡Verificar si no hay una nueva version!
 
-# Variables
+## Variables
 
 Las variables se han separado en archivos según la siguiente clasificación:
 
-## Docker
+### Docker
 
 Estas variables son un wrapper de aquellas usadas por el [role del que
 dependemos](https://github.com/geerlingguy/ansible-role-docker):
@@ -69,17 +68,52 @@ dependemos](https://github.com/geerlingguy/ansible-role-docker):
 | `workstation_docker_compose_version` | `2.16.0`              | Versión de compose a instalar        |
 | `workstation_docker_users`           | `{{ ansible_user }}` | Usuarios para interactuar con docker |
 
-## Locales
+### Locales
 
 Qué locales instalar en la máquina
-
 
 | Nombre                               | Default                           | Descripción |
 | ------------------------------------ | --------------------------------- | ----------- |
 | `workstation_locales`         | `[ es_ES.UTF-8, es_AR.UTF8, en_US.UTF8]` | Locales     |
 
-## Proxy
+### GitHub
 
+La instalación inicial clona muchos plugins de asdf y descarga binarios desde GitHub, lo que puede
+provocar errores HTTP 403 por rate limiting (60 requests/hora sin autenticación).
+
+Para evitarlo, configurar un token de GitHub sin scopes (alcanza con acceso público):
+
+| Nombre | Default | Descripción |
+| ------ | ------- | ----------- |
+| `workstation_github_api_token` | valor de `$GITHUB_API_TOKEN` | Token de GitHub para evitar rate limiting |
+
+La forma más práctica es usando el `.envrc.private` (ver `.envrc.private.sample`):
+
+```bash
+cp .envrc.private.sample .envrc.private
+# editar .envrc.private y completar GITHUB_API_TOKEN
+direnv allow
+```
+
+El token puede ser **Classic** o **Fine-grained**. Para este uso no se necesita
+ningún scope ni permiso — solo autenticación.
+
+> **Nota**: La organización Mikroways bloquea fine-grained tokens con lifetime
+> mayor a 366 días. Si usás fine-grained, configurá máximo 365 días de expiración.
+
+* **Classic**: [github.com/settings/tokens/new](https://github.com/settings/tokens/new)
+  * _Note_: `mw-asdf-rate-limit`
+  * _Expiration_: No expiration
+  * Sin seleccionar ningún scope
+
+* **Fine-grained**: [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new)
+  * _Token name_: `mw-asdf-rate-limit`
+  * _Description_: `Token para evitar rate limiting de GitHub al instalar plugins de asdf`
+  * _Expiration_: 365 days
+  * _Repository access_: Public repositories
+  * Sin permisos adicionales
+
+### Proxy
 
 Estas variables son un wrapper de aquellas usadas por el [role del que
 dependemos](https://github.com/ruzickap/ansible-role-proxy_settings/)
@@ -95,7 +129,7 @@ dependemos](https://github.com/ruzickap/ansible-role-proxy_settings/)
 | `workstation_proxy_yum_username` | `null` | Yum proxy username        |
 | `workstation_proxy_yum_password` | `null` | Yum proxy password        |
 
-## Dotfiles
+### Dotfiles
 
 Mikroways tiene sus propios [dotfiles](https://github.com/Mikroways/dotfiles).
 Su instalación es fundamental para tener una experiencia diferencial usando este
@@ -113,27 +147,26 @@ role. Toda configuración se rige por las siguientes variables:
 | `workstation_dotfiles_fonts_directory` | `{{ ansible_env.HOME }}/.local/share/fonts` | En consolas gráficas se usan fuentes que deben existir en el sistema. Para estos casos, se indica el directorio local de fuentes |
 | `workstation_dotfiles_fonts` | `[]` | Lista de url de las fuentes necesarias en un desktop gráfico |
 
-
-## Herramientas
+### Herramientas
 
 Las herramientas se instalan con diferentes productos:
 
 * asdf
 * Descarga de binarios en el HOME del usuario que corre el playbook.
 
-### Herramientas instaladas con asdf
+#### Herramientas instaladas con asdf
 
 Todo lo referente a asdf se configura con las siguientes variables:
 
 | Nombre                           | Default | Descripción               |
 | ----------------------------     | ------- | ------------------------- |
 | `workstation_asdf_download_url`      | `https://github.com/asdf-vm/asdf/releases/download/...` | URL de descarga de GH releases |
-| `workstation_asdf_dest` | `{{ ansible_env.HOME }}/.asdf` | Directorio donde se instalrá asdf |
+| `workstation_asdf_dest` | `{{ ansible_env.HOME }}/.asdf` | Directorio donde se instalará asdf |
 | `workstation_asdf_version` | `v0.16.7` | Version de asd |
 | `workstation_asdf_tools` | `{ plugin_name_1: [latest], plugin_name2: [] }`| Listado de versiones de diferentes herramientas a instalar. _A continuación explicamos el formato_ |
-| `workstation_asdf_external_sources_plugins` | `{plugin_1: url, plugin2: url} ` | Listado de urls desde donde instalar plugins. _A continuación explicaremos el formato_  |
+| `workstation_asdf_external_sources_plugins` | `{plugin_1: url, plugin2: url}` | Listado de urls desde donde instalar plugins. _A continuación explicaremos el formato_  |
 
-#### Formato de `workstation_asdf_tools`
+##### Formato de `workstation_asdf_tools`
 
 Es un diccionario donde se mantiene como clave, el nombre del plugin y como
 valor un listado de versiones a instalar. Si el listado de versiones es vacío,
@@ -144,15 +177,13 @@ la lista **será la configurada como versión por defecto**.
 
 Para ver un ejemplo, puede verse [`default/main/asdf.yml`](defaults/main/asdf.yml).
 
-### Herramientas instaladas con el rol y sin asdf
-
-
+#### Herramientas instaladas con el rol y sin asdf
 
 | Nombre                                | Default                                 | Descripción                            |
 | ------------------------------------- | --------------------------------------- | -------------------------------------- |
 | `workstation_tools_install_directory` | `{{ ansible_env.HOME }}/.mikroways/bin` | Directorio donde descargar utilitarios |
-| `workstation_tools_only`              | `[]`                                    | Qué utilitatios instalar de todos      |
-| `workstation_tools`                   | arreglo de utilitarios (ver abajo)      |                                        |}
+| `workstation_tools_only`              | `[]`                                    | Qué utilitarios instalar de todos      |
+| `workstation_tools`                   | arreglo de utilitarios (ver abajo)      |                                        |
 
 La variable `workstation_tools` se compone como un arreglo de arreglos separado
 en diferentes archivos que nos simplifica la gestión de las herramientas según:
@@ -161,7 +192,7 @@ en diferentes archivos que nos simplifica la gestión de las herramientas según
   no soportadas por asdf.
 * `workstation_other_tools`: otras herramientas que no se contemplan por asdf.
 
-### Helm plugins
+#### Helm plugins
 
 Lista de plugins de helm:
 
@@ -171,7 +202,7 @@ Lista de plugins de helm:
 
 > Se instalan sólo si helm fue seleccionado como tool
 
-### Krew plugins
+#### Krew plugins
 
 Lista de plugins de kubectl instalados con krew:
 
@@ -182,8 +213,7 @@ Lista de plugins de kubectl instalados con krew:
 
 > Se instalan sólo si krew fue seleccionado como tool
 
-
-# Tags ansible soportados
+## Tags ansible soportados
 
 * system_packages
 * docker
@@ -192,17 +222,17 @@ Lista de plugins de kubectl instalados con krew:
 * locales
 * proxy
 
-# Desarrollo
+## Desarrollo
 
 Para trabajar en el desarrollo del presente role, se recomienda instalar python.
 El propio repositorio mantiene variables de ambiente usando direnv dentro del
 `.envrc` y propone usar [**tox**](https://tox.wiki/) como librería para el
-desarrollo e intergración con CI/CD.
+desarrollo e integración con CI/CD.
 
 > Si ya tenés un desktop de Mikroways instalado por este role, entonces todo va
 > a ser más simple.
 
-## Instalando los requerimientos
+### Instalando los requerimientos
 
 Instalar las versiones de python con las que probar. Dado que las versiones de
 python soportadas por [ansible dependen de ansible-core](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs),
@@ -217,12 +247,13 @@ asdf reshim python
 pip3.10 install -r requirements.txt
 pip3.11 install -r requirements.txt
 ```
-## Uso de tox
+
+### Uso de tox
 
 Tox tiene una serie de comandos, pero lo más importante es comprender los
 ambientes configurados en `tox.ini`. Los ambientes pueden verse con:
 
-```
+```shell
 tox list
 ```
 
@@ -230,7 +261,7 @@ Al correr simplemente `tox` se ejecuta `tox run`. Pero nosotros podemos
 manipular `tox run` con las opciones que se ven con `--help`. Lo más importante
 a mencionar es:
 
-```
+```shell
 tox r -e py310-ansible-10 -- -vvv converge
 ```
 
@@ -241,10 +272,10 @@ tox r -e py310-ansible-10 -- -vvv converge
 Otro comando útil con tox, es ejecutar otro comando, por ejemplo ansible-lint.
 ¿Cómo es posible hacer eso?:
 
-```
+```shell
 tox exec -e py310-ansible-10 -- ansible-lint .
 ```
 
-# TODO
+## TODO
 
 * [ ] Analizar si funcionan los tags mencionados

--- a/defaults/main/github.yml
+++ b/defaults/main/github.yml
@@ -1,0 +1,5 @@
+---
+# GitHub API token to avoid rate limiting when downloading plugins and assets.
+# Create one at https://github.com/settings/tokens (no scopes needed for public repos).
+# Can also be set via environment variable GITHUB_API_TOKEN before running the playbook.
+workstation_github_api_token: "{{ lookup('env', 'GITHUB_API_TOKEN') }}"

--- a/tasks/_download.yml
+++ b/tasks/_download.yml
@@ -30,6 +30,7 @@
         dest: "{{ tempfile.path }}"
         mode: '0600'
         force: true
+        headers: "{{ {'Authorization': 'token ' + workstation_github_api_token} if (workstation_github_api_token and 'github.com' in url) else {} }}"
 
     - name: "Install {{ _name }}"
       ansible.builtin.shell: >-

--- a/tasks/asdf.yml
+++ b/tasks/asdf.yml
@@ -38,6 +38,7 @@
   changed_when: false
   environment:
     PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    GITHUB_API_TOKEN: "{{ workstation_github_api_token }}"
   when: item.key not in asdf_plugin_list_output.stdout_lines
   loop: "{{ workstation_asdf_tools | dict2items }}"
   loop_control:
@@ -50,6 +51,7 @@
   changed_when: false
   environment:
     PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    GITHUB_API_TOKEN: "{{ workstation_github_api_token }}"
 
 - name: "Check asdf version tools installed"
   ansible.builtin.shell: |
@@ -80,6 +82,7 @@
   when: asdf_version_installed.results[asdf_tool_idx].rc != 0
   environment:
     PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    GITHUB_API_TOKEN: "{{ workstation_github_api_token }}"
   loop: "{{ workstation_asdf_tools | dict2items | subelements('value') }}"
   loop_control:
     label: "Installing asdf {{ item.0.key }}@{{ item.1 }}"

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -17,6 +17,7 @@
     url: "{{ workstation_antigen_url }}"
     dest: "{{ workstation_antigen_directory }}/antigen.zsh"
     mode: "0755"
+    headers: "{{ {'Authorization': 'token ' + workstation_github_api_token} if (workstation_github_api_token and 'github.com' in workstation_antigen_url) else {} }}"
   register: uri_output
   until: uri_output.status_code == 200
   retries: 5
@@ -50,6 +51,7 @@
         url: "{{ item }}"
         mode: "0644"
         dest: "{{ workstation_dotfiles_fonts_directory }}/{{ item | basename }}"
+        headers: "{{ {'Authorization': 'token ' + workstation_github_api_token} if (workstation_github_api_token and 'github.com' in item) else {} }}"
       loop: "{{ workstation_dotfiles_fonts }}"
 -
   name: "Set direnv configuration directory"


### PR DESCRIPTION
## Summary

Agrega soporte para `GITHUB_API_TOKEN` en el rol para evitar errores HTTP 403 por rate limiting de GitHub durante la instalación inicial de plugins de asdf y descarga de binarios.

## Cambios

* `defaults/main/github.yml`: nueva variable `workstation_github_api_token` que lee de `$GITHUB_API_TOKEN`
* `tasks/asdf.yml`: pasa el token al environment de `asdf plugin add`, `asdf plugin update` y `asdf install`
* `tasks/_download.yml`: agrega header `Authorization` en `get_url` cuando la URL es de GitHub
* `tasks/dotfiles.yml`: mismo header para descarga de antigen y fonts
* `.envrc`: agrega `source_env_if_exists .envrc.private` para cargar secrets locales
* `.envrc.private.sample`: archivo de ejemplo para configurar el token
* `.gitignore`: agrega `.envrc.private`
* `README.md`: documenta la variable, cómo crear el token y la restricción de fine-grained en la org Mikroways

Closes #36