### PR TITLE
refactor: migrar facts inyectados a ansible_facts[]

### DIFF
--- a/defaults/main/asdf.yml
+++ b/defaults/main/asdf.yml
@@ -1,6 +1,6 @@
 ---
-workstation_asdf_download_url: "https://github.com/asdf-vm/asdf/releases/download/{{ workstation_asdf_version }}/asdf-{{ workstation_asdf_version }}-{{ ansible_system | lower }}-amd64.tar.gz"
-workstation_asdf_dest: '{{ ansible_env.HOME }}/.asdf'
+workstation_asdf_download_url: "https://github.com/asdf-vm/asdf/releases/download/{{ workstation_asdf_version }}/asdf-{{ workstation_asdf_version }}-{{ ansible_facts['system'] | lower }}-amd64.tar.gz"
+workstation_asdf_dest: '{{ ansible_facts["env"]["HOME"] }}/.asdf'
 workstation_asdf_version: v0.16.7
 workstation_asdf_tools:
   age: [ latest ]

--- a/defaults/main/dotfiles.yml
+++ b/defaults/main/dotfiles.yml
@@ -1,12 +1,12 @@
 ---
 workstation_dotfiles_enabled: true
-workstation_antigen_directory: "{{ ansible_env.HOME }}/.antigen.zsh"
+workstation_antigen_directory: "{{ ansible_facts['env']['HOME'] }}/.antigen.zsh"
 workstation_antigen_url: "https://git.io/antigen"
-workstation_dotfiles_directory: "{{ ansible_env.HOME }}/.mikroways/dotfiles"
+workstation_dotfiles_directory: "{{ ansible_facts['env']['HOME'] }}/.mikroways/dotfiles"
 workstation_dotfiles_repository: "https://github.com/Mikroways/dotfiles.git"
 workstation_dotfiles_version: "master"
 workstation_dotfiles_install_script: "{{ workstation_dotfiles_directory }}/script/install"
-workstation_dotfiles_fonts_directory: "{{ ansible_env.HOME }}/.local/share/fonts"
+workstation_dotfiles_fonts_directory: "{{ ansible_facts['env']['HOME'] }}/.local/share/fonts"
 workstation_dotfiles_fonts:
   - https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Regular.ttf
   - https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Bold.ttf

--- a/defaults/main/krew-plugins.yml
+++ b/defaults/main/krew-plugins.yml
@@ -1,5 +1,5 @@
 ---
-workstation_krew_path: "{{ ansible_env.HOME }}/.krew/bin"
+workstation_krew_path: "{{ ansible_facts['env']['HOME'] }}/.krew/bin"
 workstation_krew_plugins:
   - ctx
   - ns

--- a/defaults/main/tools-kubernetes.yml
+++ b/defaults/main/tools-kubernetes.yml
@@ -3,7 +3,7 @@ workstation_kubernetes_tools:
   -
     name: sonobuoy
     url: >-
-      https://github.com/vmware-tanzu/sonobuoy/releases/download/v%version%/sonobuoy_%version%_{{ ansible_system | lower }}_amd64.tar.gz
+      https://github.com/vmware-tanzu/sonobuoy/releases/download/v%version%/sonobuoy_%version%_{{ ansible_facts['system'] | lower }}_amd64.tar.gz
     version: '0.56.16'
     install_command: >-
       tar xfz %downloaded% -C %install_directory% sonobuoy

--- a/defaults/main/tools-others.yml
+++ b/defaults/main/tools-others.yml
@@ -3,37 +3,37 @@ workstation_other_tools:
   -
     name: navi
     url: >-
-      https://github.com/denisidoro/navi/releases/download/v%version%/navi-v%version%-x86_64-unknown-{{ ansible_system | lower }}-musl.tar.gz
+      https://github.com/denisidoro/navi/releases/download/v%version%/navi-v%version%-x86_64-unknown-{{ ansible_facts['system'] | lower }}-musl.tar.gz
     version: '2.22.1'
     install_command: "tar xfz %downloaded% -C %install_directory% ./navi"
     version_command: "navi -V"
   -
     name: govc
     url: >-
-      https://github.com/vmware/govmomi/releases/download/v%version%/govc_{{ ansible_system }}_x86_64.tar.gz
+      https://github.com/vmware/govmomi/releases/download/v%version%/govc_{{ ansible_facts['system'] }}_x86_64.tar.gz
     version: '0.51.0'
     install_command: "tar xfz %downloaded% -C %install_directory% govc"
     version_command: "govc version"
   -
     name: amtool
     url: >-
-      https://github.com/prometheus/alertmanager/releases/download/v%version%/alertmanager-%version%.{{ ansible_system | lower }}-amd64.tar.gz
+      https://github.com/prometheus/alertmanager/releases/download/v%version%/alertmanager-%version%.{{ ansible_facts['system'] | lower }}-amd64.tar.gz
     version: '0.24.0'
     install_command: >-
-      tar xfz %downloaded% -C %install_directory% alertmanager-%version%.{{ ansible_system | lower }}-amd64/amtool --strip-components=1
+      tar xfz %downloaded% -C %install_directory% alertmanager-%version%.{{ ansible_facts['system'] | lower }}-amd64/amtool --strip-components=1
     version_command: "amtool --version"
   -
     name: promtool
     url: >-
-      https://github.com/prometheus/prometheus/releases/download/v%version%/prometheus-%version%.{{ ansible_system | lower }}-amd64.tar.gz
+      https://github.com/prometheus/prometheus/releases/download/v%version%/prometheus-%version%.{{ ansible_facts['system'] | lower }}-amd64.tar.gz
     version: '2.39.1'
     install_command: >-
-      tar xfz %downloaded% -C %install_directory% prometheus-%version%.{{ ansible_system | lower }}-amd64/promtool --strip-components=1
+      tar xfz %downloaded% -C %install_directory% prometheus-%version%.{{ ansible_facts['system'] | lower }}-amd64/promtool --strip-components=1
     version_command: "promtool --version"
   -
     name: certinfo
     url: >-
-      https://github.com/pete911/certinfo/releases/download/v%version%/certinfo_%version%_{{ ansible_system | lower }}_amd64.tar.gz
+      https://github.com/pete911/certinfo/releases/download/v%version%/certinfo_%version%_{{ ansible_facts['system'] | lower }}_amd64.tar.gz
     version: '1.0.7'
     install_command: >-
       tar xfz %downloaded% -C %install_directory% certinfo
@@ -41,7 +41,7 @@ workstation_other_tools:
   -
     name: gitlab-runner
     url: >-
-      https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/v%version%/binaries/gitlab-runner-{{ ansible_system | lower }}-amd64
+      https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/v%version%/binaries/gitlab-runner-{{ ansible_facts['system'] | lower }}-amd64
     version: '15.11.1'
     install_command: >-
       chmod +x %downloaded% &&
@@ -53,6 +53,6 @@ workstation_other_tools:
       https://github.com/junegunn/fzf/archive/refs/tags/v%version%.tar.gz
     version: '0.64.0'
     install_command: >-
-      tar xfz %downloaded% --one-top-level={{ ansible_env.HOME }}/.fzf --strip-components 1 &&
-      {{ ansible_env.HOME }}/.fzf/install --all
-    version_command: "{{ ansible_env.HOME }}/.fzf/bin/fzf --version"
+      tar xfz %downloaded% --one-top-level={{ ansible_facts['env']['HOME'] }}/.fzf --strip-components 1 &&
+      {{ ansible_facts['env']['HOME'] }}/.fzf/install --all
+    version_command: "{{ ansible_facts['env']['HOME'] }}/.fzf/bin/fzf --version"

--- a/defaults/main/tools.yml
+++ b/defaults/main/tools.yml
@@ -1,5 +1,5 @@
 ---
-workstation_tools_install_directory: "{{ ansible_env.HOME }}/.mikroways/bin"
+workstation_tools_install_directory: "{{ ansible_facts['env']['HOME'] }}/.mikroways/bin"
 
 # Install only these tools. If empty, all tools will be installed
 workstation_tools_only: []

--- a/tasks/_download.yml
+++ b/tasks/_download.yml
@@ -11,7 +11,7 @@
   changed_when: false
 
   environment:
-    PATH: "{{ install_directory }}:{{ ansible_env.PATH }}"
+    PATH: "{{ install_directory }}:{{ ansible_facts['env']['PATH'] }}"
   tags:
     - skip_ansible_lint
 
@@ -59,4 +59,4 @@
           ( just_installed.rc == 0 and version not in just_installed.stdout )
       changed_when: false
       environment:
-        PATH: "{{ install_directory }}:{{ ansible_env.PATH }}"
+        PATH: "{{ install_directory }}:{{ ansible_facts['env']['PATH'] }}"

--- a/tasks/asdf.yml
+++ b/tasks/asdf.yml
@@ -21,7 +21,7 @@
 - name: "Create default python packages"
   ansible.builtin.copy:
     content: "{{ workstation_default_python_packages | join('\n') }}\n"
-    dest: "{{ ansible_env.HOME }}/.default-python-packages"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.default-python-packages"
     mode: "0644"
 
 - name: "Check asdf installed plugins"
@@ -30,7 +30,7 @@
   failed_when: asdf_plugin_list_output.rc not in [0 , 1]
   changed_when: false
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_facts['env']['PATH'] }}"
 
 - name: "Add asdf plugins"
   ansible.builtin.command: "asdf plugin add {{ item.key }} {{ workstation_asdf_external_sources_plugins.get(item.key, '') }}"
@@ -38,7 +38,7 @@
   failed_when: asdf_output.rc != 0
   changed_when: false
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_facts['env']['PATH'] }}"
     GITHUB_API_TOKEN: "{{ workstation_github_api_token }}"
   when: item.key not in asdf_plugin_list_output.stdout_lines
   loop: "{{ workstation_asdf_tools | dict2items }}"
@@ -51,7 +51,7 @@
   failed_when: asdf_output.rc != 0
   changed_when: false
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_facts['env']['PATH'] }}"
     GITHUB_API_TOKEN: "{{ workstation_github_api_token }}"
 
 - name: "Check asdf version tools installed"
@@ -69,7 +69,7 @@
   failed_when: false
   changed_when: false
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ workstation_asdf_tools | dict2items | subelements('value') }}"
   loop_control:
     label: "Checking asdf {{ item.0.key }}@{{ item.1 }}"
@@ -85,7 +85,7 @@
   until: asdf_output.rc == 0
   when: asdf_version_installed.results[asdf_tool_idx].rc != 0
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_facts['env']['PATH'] }}"
     GITHUB_API_TOKEN: "{{ workstation_github_api_token }}"
   loop: "{{ workstation_asdf_tools | dict2items | subelements('value') }}"
   loop_control:
@@ -99,7 +99,7 @@
   changed_when: false
   when: item.value | length > 0
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ workstation_asdf_tools | dict2items }}"
   loop_control:
     label: >-
@@ -111,7 +111,7 @@
 
 - name: "Set asdf direnv configuration directory"
   ansible.builtin.set_fact:
-    asdf_direnv_plugin_config_dir: "{{ ansible_user_dir }}/.config/direnv/lib"
+    asdf_direnv_plugin_config_dir: "{{ ansible_facts['user_dir'] }}/.config/direnv/lib"
 
 - name: "Create asdf direnv configuration directory"
   ansible.builtin.file:

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -56,7 +56,7 @@
 -
   name: "Set direnv configuration directory"
   ansible.builtin.set_fact:
-    direnv_config_dir: "{{ ansible_user_dir }}/.config/direnv/lib"
+    direnv_config_dir: "{{ ansible_facts['user_dir'] }}/.config/direnv/lib"
 
 -
   name: "Create direnv configuration directory"

--- a/tasks/helm-plugins.yml
+++ b/tasks/helm-plugins.yml
@@ -5,7 +5,7 @@
   changed_when: false
   ignore_errors: yes
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_facts['env']['PATH'] }}"
 -
   name: Do install and upgrade helm plugins when installed
   when: helm_check.rc == 0
@@ -15,11 +15,11 @@
       register: helm_plugins_installed
       changed_when: false
       environment:
-        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"
+        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_facts['env']['PATH'] }}"
     - name: Install helm plugins
       ansible.builtin.command: "helm plugin install {{ item.repo }} --verify=false"
       loop: "{{ workstation_helm_plugins }}"
       when: item.name not in helm_plugins_installed.stdout
       changed_when: true
       environment:
-        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"
+        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_facts['env']['PATH'] }}"

--- a/tasks/krew-plugins.yml
+++ b/tasks/krew-plugins.yml
@@ -5,7 +5,7 @@
   changed_when: false
   ignore_errors: yes
   environment:
-    PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"
+    PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_facts['env']['PATH'] }}"
 -
   name: Do install and upgrade krew plugins when installed
   when: krew_check.rc == 0
@@ -17,10 +17,10 @@
       changed_when: krew_install.rc == 0 and 'installed' in krew_install.stdout
       loop: "{{ workstation_krew_plugins }}"
       environment:
-        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"
+        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_facts['env']['PATH'] }}"
     -
       name: Upgrade krew plugins
       ansible.builtin.command: "krew upgrade"
       changed_when: false
       environment:
-        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_env.PATH }}"
+        PATH: "{{ workstation_asdf_dest }}/bin:{{ workstation_asdf_dest }}/shims:{{ workstation_tools_install_directory }}:{{ ansible_facts['env']['PATH'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     docker_install_compose: "{{ workstation_docker_install_compose }}"
     docker_compose_version: "{{ workstation_docker_compose_version }}"
     docker_install_compose_plugin: "{{ workstation_docker_install_compose_plugin }}"
-  when: workstation_docker_enabled and ansible_os_family | lower != "archlinux"
+  when: workstation_docker_enabled and ansible_facts['os_family'] | lower != "archlinux"
   tags:
     - docker
 -

--- a/tasks/system_packages.yml
+++ b/tasks/system_packages.yml
@@ -2,11 +2,11 @@
 - name: Debug detected distribution facts
   ansible.builtin.debug:
     msg: |
-      ansible_distribution: {{ ansible_distribution | default('undefined') }}
-      ansible_distribution_version: {{ ansible_distribution_version | default('undefined') }}
-      ansible_distribution_major_version: {{ ansible_distribution_major_version | default('undefined') }}
-      ansible_os_family: {{ ansible_os_family | default('undefined') }}
-      ansible_pkg_mgr: {{ ansible_pkg_mgr | default('undefined') }}
+      ansible_facts['distribution']: {{ ansible_facts['distribution'] | default('undefined') }}
+      ansible_facts['distribution_version']: {{ ansible_facts['distribution_version'] | default('undefined') }}
+      ansible_facts['distribution_major_version']: {{ ansible_facts['distribution_major_version'] | default('undefined') }}
+      ansible_facts['os_family']: {{ ansible_facts['os_family'] | default('undefined') }}
+      ansible_facts['pkg_mgr']: {{ ansible_facts['pkg_mgr'] | default('undefined') }}
   tags:
     - debug
 
@@ -18,12 +18,12 @@
   vars:
     _params:
       files:
-        - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-        - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-        - "{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}-{{ ansible_distribution_version | lower }}.yml"
-        - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_version'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
       paths:
         - "../vars"
       skip: true
@@ -33,7 +33,7 @@
     file: "{{ system_package_file }}"
   with_first_found:
     - files:
-        - system_packages_{{ ansible_os_family | lower }}.yml
+        - system_packages_{{ ansible_facts['os_family'] | lower }}.yml
       skip: True
   loop_control:
     loop_var: system_package_file
@@ -49,7 +49,7 @@
   delay: 10
 -
   name: Install Arch packages using yay
-  when: ansible_os_family | lower == "archlinux"
+  when: ansible_facts['os_family'] | lower == "archlinux"
   block:
     - name: Check if yay is already installed
       ansible.builtin.command: yay --version
@@ -81,7 +81,7 @@
       changed_when: false
 -
   name: Setup configured locale
-  when: ansible_os_family | lower in ['debian', 'debianlike', 'ubuntu'] or (ansible_distribution | lower).startswith('ubuntu')
+  when: ansible_facts['os_family'] | lower in ['debian', 'debianlike', 'ubuntu'] or (ansible_facts['distribution'] | lower).startswith('ubuntu')
   block:
     - name: Setup configured locale
       community.general.locale_gen:

--- a/tasks/system_packages_debian.yml
+++ b/tasks/system_packages_debian.yml
@@ -36,4 +36,4 @@
       ansible.builtin.apt:
         name: systemd-resolved
         state: present
-      when: ansible_distribution | lower == 'debian'
+      when: ansible_facts['distribution'] | lower == 'debian'

--- a/tasks/system_packages_redhat.yml
+++ b/tasks/system_packages_redhat.yml
@@ -18,14 +18,14 @@
 
     - name: Install epel-release RPM from Fedora if package not available
       ansible.builtin.get_url:
-        url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+        url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
         dest: /tmp/epel-release.rpm
         mode: "0644"
       when: epel_install is failed or (epel_install is defined and epel_install.rc is defined and epel_install.rc != 0)
 
     - name: Import EPEL GPG key from Fedora project
       ansible.builtin.rpm_key:
-        key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+        key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}"
         state: present
       when: epel_install is failed or (epel_install is defined and epel_install.rc is defined and epel_install.rc != 0)
 

--- a/vars/ubuntu-20.04.yml
+++ b/vars/ubuntu-20.04.yml
@@ -39,4 +39,4 @@ workstation_apt_keys:
   - url: https://apt.releases.hashicorp.com/gpg
     id: 798AEC654E5C15428C8E42EEAA16FCBCA621E701
 workstation_repositories:
-  - repo: deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main
+  - repo: deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_facts['distribution_release'] }} main


### PR DESCRIPTION
## Qué cambia

Migración mecánica de los facts inyectados como variables top-level a la notación `ansible_facts[...]`: `ansible_distribution*`, `ansible_os_family`, `ansible_pkg_mgr`, `ansible_system`, `ansible_env.*` y `ansible_user_dir`. 55 líneas en 16 archivos, **sin cambio funcional**.

## Por qué

`INJECT_FACTS_AS_VARS` está deprecado y **se elimina en ansible-core 2.24**. Desde ansible 13 (core 2.20) cada corrida del role emite deprecation warnings señalando cada uso. Misma migración que ya hizo Mikroways/mikroways.authkeysync#5.

## Notas

- `molecule/default/create.yml` se excluye a propósito: es copia temporal del playbook de molecule-plugins y se elimina completo cuando se resuelva ansible-community/molecule-plugins#363.
- Los `ansible_user` restantes son la variable de conexión (no un fact), quedan como están.
- Verificación: además del CI (matriz ansible 11/13/14, 4 plataformas), los logs de las celdas ansible13/14 no deben mostrar ningún `DEPRECATION WARNING` de `INJECT_FACTS_AS_VARS` — antes de este cambio aparecían ~8 por corrida.