### PR TITLE
fix: instalar dependencias del role automáticamente con ansible-galaxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ a trabajar.
 
 ## Requerimientos
 
-Dependemos de los roles especificados en [`meta/requirements.yml`](meta/requirements.yml).
-Por ello, cuando se instale este role, se instalarán los roles que son
-dependencias de forma automática.
+Este role depende de `geerlingguy.docker` y `ruzickap.proxy_settings`. Al
+instalarlo con `ansible-galaxy role install`, las dependencias se instalan
+de forma automática: están declaradas en [`meta/main.yml`](meta/main.yml)
+con `when: false` — ansible-galaxy las resuelve en la instalación, pero no
+se ejecutan como meta-dependencias (aparecen como tareas salteadas al inicio
+de cada corrida); el role las importa con `import_role` en el orden correcto
+y según las variables `workstation_docker_enabled` / `workstation_proxy_enabled`.
+
+Las mismas dependencias están también en
+[`meta/requirements.yml`](meta/requirements.yml), que usan los tests de
+molecule. **Al actualizar una versión, actualizarla en ambos archivos.**
 
 **Es muy importante leer su documentación**, porque si bien este role, maneja
 algunos valores de estos roles, otros valores más específicos pueden setearse

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,4 +28,17 @@ galaxy_info:
   galaxy_tags:
     - devops
     - packages
-dependencies: []
+# Declaradas solo para que ansible-galaxy las instale automáticamente al
+# instalar este role. Nunca se ejecutan como meta-dependencias (when: false):
+# el role las importa con import_role en el orden correcto (system_packages
+# prepara apt antes de docker) y con sus condiciones (workstation_*_enabled).
+# Mantener versiones sincronizadas con meta/requirements.yml (usado por los
+# tests de molecule).
+dependencies:
+  - name: geerlingguy.docker
+    version: '8.0.0'
+    when: false
+  - name: ruzickap.proxy_settings
+    src: https://github.com/ruzickap/ansible-role-proxy_settings
+    version: 'v0.3.0'
+    when: false


### PR DESCRIPTION
## Problema

Instalar `mikroways.workstation` con `ansible-galaxy role install` no instala sus dependencias (`geerlingguy.docker`, `ruzickap.proxy_settings`): están declaradas en `meta/requirements.yml`, que ansible-galaxy **no lee** durante la instalación. En una máquina nueva el playbook falla con `role not found`. Reportado por @Intimaria en Mikroways/vm-setup#14.

## Solución

Declarar las dependencias también en `meta/main.yml` con `when: false`, separando **instalación** de **ejecución**:

- `ansible-galaxy role install` resuelve `dependencies` de `meta/main.yml` → las instala automáticamente. Un solo comando instala todo.
- En ejecución, las meta-dependencias se saltean siempre (`when: false`); el role las sigue importando con `import_role` donde corresponde — preservando el orden (`system_packages` prepara apt **antes** de docker) y las condiciones (`workstation_docker_enabled` / `workstation_proxy_enabled`).

### Por qué no declararlas ejecutables en meta/main.yml

Se verificó experimentalmente (A/B, misma imagen fresca de ubuntu 22.04, única variable `meta/main.yml`): como meta-dependencias ejecutables, Ansible corre docker **antes** que cualquier task del role, contra un apt sin actualizar → falla determinística (`No package matching 'python3-debian'`). Con la arquitectura actual + `when: false`: converge idéntico al baseline (`ok=122 changed=52 failed=0`).

## Verificación

- Instalación desde cero en directorio limpio: los 3 roles se instalan con un solo `ansible-galaxy role install -r requirements.yml` ✓
- Converge en ubuntu-2204: verde, recap idéntico al baseline ✓
- Único efecto visible: ~47 tareas `skipping` adicionales al inicio de cada corrida (meta-deps salteándose), documentado en README y `meta/main.yml`.
- `meta/requirements.yml` se mantiene (lo usan los tests de molecule); README documenta que ambos archivos deben actualizarse juntos.

Cierra el problema de fondo de Mikroways/vm-setup#14.