### PR TITLE
Revert: instalar dependencias del role automáticamente con ansible-galaxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,9 @@ a trabajar.
 
 ## Requerimientos
 
-Este role depende de `geerlingguy.docker` y `ruzickap.proxy_settings`. Al
-instalarlo con `ansible-galaxy role install`, las dependencias se instalan
-de forma automática: están declaradas en [`meta/main.yml`](meta/main.yml)
-con `when: false` — ansible-galaxy las resuelve en la instalación, pero no
-se ejecutan como meta-dependencias (aparecen como tareas salteadas al inicio
-de cada corrida); el role las importa con `import_role` en el orden correcto
-y según las variables `workstation_docker_enabled` / `workstation_proxy_enabled`.
-
-Las mismas dependencias están también en
-[`meta/requirements.yml`](meta/requirements.yml), que usan los tests de
-molecule. **Al actualizar una versión, actualizarla en ambos archivos.**
+Dependemos de los roles especificados en [`meta/requirements.yml`](meta/requirements.yml).
+Por ello, cuando se instale este role, se instalarán los roles que son
+dependencias de forma automática.
 
 **Es muy importante leer su documentación**, porque si bien este role, maneja
 algunos valores de estos roles, otros valores más específicos pueden setearse

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,17 +28,4 @@ galaxy_info:
   galaxy_tags:
     - devops
     - packages
-# Declaradas solo para que ansible-galaxy las instale automáticamente al
-# instalar este role. Nunca se ejecutan como meta-dependencias (when: false):
-# el role las importa con import_role en el orden correcto (system_packages
-# prepara apt antes de docker) y con sus condiciones (workstation_*_enabled).
-# Mantener versiones sincronizadas con meta/requirements.yml (usado por los
-# tests de molecule).
-dependencies:
-  - name: geerlingguy.docker
-    version: '8.0.0'
-    when: false
-  - name: ruzickap.proxy_settings
-    src: https://github.com/ruzickap/ansible-role-proxy_settings
-    version: 'v0.3.0'
-    when: false
+dependencies: []


### PR DESCRIPTION
Revierte #60.

## Por qué

La premisa de #60 era incorrecta: `ansible-galaxy role install` **sí** resuelve e instala las dependencias declaradas en `meta/requirements.yml` del role, sin necesitar el `when: false` en `meta/main.yml`. Verificado en máquina limpia (ver Mikroways/vm-setup#15, donde Christian reprodujo la instalación completa sin problemas).

El `when: false` no arreglaba ningún caso real y sumaba ruido: ~35 tareas `skipping` de docker/proxy al inicio de cada corrida del playbook.

## Causa real del `role not found` reportado originalmente (Mikroways/vm-setup#14)

`ansible-galaxy` no procesa las dependencias de un role que ya está presente en el roles path — si hay un estado parcial en `ansible/roles/` (instalación anterior interrumpida, Ctrl-C, lo que sea), el comando documentado dice `already installed, skipping` y las dependencias del role salteado nunca se instalan. Reproducido con los archivos reales del repo (`roles-mw.yml`) en Mikroways/vm-setup#15.

Esto no depende de `meta/main.yml` — el fix real es documental (conectar el síntoma con `--force-with-deps` o limpiar `ansible/roles/`), a resolver en vm-setup.

## Verificación

yamllint, ansible-lint (perfil production) y `molecule syntax` en verde. El CI de este PR corre la matriz completa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)